### PR TITLE
Bump clamav/clamav from 1.2.1-26 to 1.2.1-27 in /Containers/clamav

### DIFF
--- a/Containers/clamav/Dockerfile
+++ b/Containers/clamav/Dockerfile
@@ -1,5 +1,5 @@
 # Probably from this file: https://github.com/Cisco-Talos/clamav-docker/blob/main/clamav/1.1/alpine/Dockerfile
-FROM clamav/clamav:1.2.1-26
+FROM clamav/clamav:1.2.1-27
 
 COPY clamav.conf /tmp/clamav.conf
 


### PR DESCRIPTION
Bumps clamav/clamav from 1.2.1-26 to 1.2.1-27.

---
updated-dependencies:
- dependency-name: clamav/clamav dependency-type: direct:production update-type: version-update:semver-patch ...